### PR TITLE
chore: retarget fork references to workera-ai and bump to 2.0.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Tag version
-        uses: wendbv/calver-tag-action@main
+        uses: workera-ai/calver-tag-action@main
         with:
           output-only: true
         id: tag-version

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: wendbv/calver-tag-action@v1
+      - uses: workera-ai/calver-tag-action@v2
 ```
 
 You can also pass in a prerelease and disable the prefix, this will generate a version like `2021.1.0-beta.0`.
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: wendbv/calver-tag-action@v1
+      - uses: workera-ai/calver-tag-action@v2
         with:
           prerelease: beta
           prefix: ''
@@ -61,7 +61,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: wendbv/calver-tag-action@v1
+      - uses: workera-ai/calver-tag-action@v2
         id: tag-version
         with:
           output-only: true

--- a/package.json
+++ b/package.json
@@ -1,19 +1,19 @@
 {
   "name": "calver-tag-action",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "",
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/wendbv/calver-tag-action.git"
+    "url": "git+https://github.com/workera-ai/calver-tag-action.git"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/wendbv/calver-tag-action-action/issues"
+    "url": "https://github.com/workera-ai/calver-tag-action/issues"
   },
-  "homepage": "https://github.com/wendbv/calver-tag-action-action#readme",
+  "homepage": "https://github.com/workera-ai/calver-tag-action#readme",
   "dependencies": {
     "@actions/core": "^1.2.6",
     "@actions/exec": "^1.0.4",


### PR DESCRIPTION
## Motivation

The README, `package.json` metadata, and the repo's own CI still referenced the upstream `wendbv/calver-tag-action` fork rather than this repository. The CI reference is a real defect: `.github/workflows/main.yml` ran `wendbv/calver-tag-action@main`, so it exercised the fork's action instead of this code, meaning recent changes were never tested by CI here.

This is release-prep for `v2.0.0`.

## Proposed solution

- Point the README usage examples at `workera-ai/calver-tag-action@v2`.
- Point CI at `workera-ai/calver-tag-action@main` so the repo self-tests.
- Correct the `repository`, `bugs`, and `homepage` URLs in `package.json` to this org, fixing the doubled `-action-action` typo in the bugs/homepage URLs.
- Bump the package version to `2.0.0` to match the upcoming release.

No code or behavior changes; docs and metadata only.

## Checklists

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)